### PR TITLE
[M0] GET /api/club/me — organisation active + rôle + permissions

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { MailModule } from "./mail/mail.module";
 import { AuthModule } from "./auth/auth.module";
 import { OrganizationModule } from "./organization/organization.module";
 import { UserModule } from "./user/user.module";
+import { ClubModule } from "./club/club.module";
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { UserModule } from "./user/user.module";
     MailModule,
     OrganizationModule,
     UserModule,
+    ClubModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/club/club.controller.ts
+++ b/src/club/club.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import {
+  AuthGuard,
+  Session,
+  type UserSession,
+} from "@thallesp/nestjs-better-auth";
+
+import { ClubService } from "./club.service";
+
+@Controller("club")
+@UseGuards(AuthGuard)
+export class ClubController {
+  constructor(private readonly club: ClubService) {}
+
+  @Get("me")
+  me(@Session() session: UserSession) {
+    return this.club.getSpaceForCaller(
+      session.user.id,
+      session.session.activeOrganizationId,
+    );
+  }
+}

--- a/src/club/club.module.ts
+++ b/src/club/club.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { OrganizationEntity } from "~/organization/entities/organization.entity";
+import { MemberEntity } from "~/organization/entities/member.entity";
+import { OrganizationModule } from "~/organization/organization.module";
+import { ClubController } from "./club.controller";
+import { ClubService } from "./club.service";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([OrganizationEntity, MemberEntity]),
+    OrganizationModule,
+  ],
+  controllers: [ClubController],
+  providers: [ClubService],
+})
+export class ClubModule {}

--- a/src/club/club.service.ts
+++ b/src/club/club.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { OrganizationEntity } from "~/organization/entities/organization.entity";
+import { MemberEntity } from "~/organization/entities/member.entity";
+import { OrganizationService } from "~/organization/organization.service";
+import { OrgPermissions } from "~/organization/config/roles.config";
+
+export interface ClubSpace {
+  organization: {
+    id: string;
+    name: string;
+    slug: string;
+    createdAt: Date;
+  };
+  member: {
+    id: string;
+    role: string;
+    permissions: OrgPermissions;
+  };
+}
+
+@Injectable()
+export class ClubService {
+  constructor(
+    @InjectRepository(OrganizationEntity)
+    private readonly organizations: Repository<OrganizationEntity>,
+    @InjectRepository(MemberEntity)
+    private readonly members: Repository<MemberEntity>,
+    private readonly organizationService: OrganizationService,
+  ) {}
+
+  async getSpaceForCaller(
+    userId: string,
+    activeOrganizationId?: string,
+  ): Promise<ClubSpace> {
+    if (!activeOrganizationId) {
+      throw new NotFoundException("Aucune organisation active");
+    }
+
+    const member = await this.members.findOneBy({
+      userId,
+      organizationId: activeOrganizationId,
+    });
+    if (!member) {
+      throw new NotFoundException(
+        "Vous n'êtes pas membre de cette organisation",
+      );
+    }
+
+    const organization = await this.organizations.findOneBy({
+      id: activeOrganizationId,
+    });
+    if (!organization) {
+      throw new NotFoundException("Organisation introuvable");
+    }
+
+    const permissions = await this.organizationService.resolveRolePermissions(
+      activeOrganizationId,
+      member.role,
+    );
+
+    return {
+      organization: {
+        id: organization.id,
+        name: organization.name,
+        slug: organization.slug,
+        createdAt: organization.createdAt,
+      },
+      member: {
+        id: member.id,
+        role: member.role,
+        permissions,
+      },
+    };
+  }
+}

--- a/src/organization/organization.service.ts
+++ b/src/organization/organization.service.ts
@@ -17,6 +17,7 @@ import { OrganizationRoleEntity } from "./entities/organization-role.entity";
 import { InvitationEntity } from "./entities/invitation.entity";
 import {
   ORG_PERMISSION_STATEMENTS,
+  ORG_ROLES,
   ORG_ROLES_PUBLIC,
   OrgPermissions,
   OrgRolePublic,
@@ -95,6 +96,20 @@ export class OrganizationService {
 
   getStatements() {
     return ORG_PERMISSION_STATEMENTS;
+  }
+
+  async resolveRolePermissions(
+    orgId: string,
+    role: string,
+  ): Promise<OrgPermissions> {
+    if (Object.prototype.hasOwnProperty.call(ORG_ROLES, role)) {
+      return ORG_ROLES[role].permissions;
+    }
+    const custom = await this.customRoles.findOneBy({
+      organizationId: orgId,
+      role,
+    });
+    return custom ? parsePermission(custom.permission) : {};
   }
 
   async findOne(id: string): Promise<OrganizationDetail> {


### PR DESCRIPTION
Implémente `GET /api/club/me` : un seul appel pour hydrater l'espace club.

## Ce qui est fait
- **`ClubController` → `GET /api/club/me`** (`src/club/`), protégé par `AuthGuard`
- Résout le membership du caller dans l'org active (`session.session.activeOrganizationId`)
- Retourne `{ organization: { id, name, slug, createdAt }, member: { id, role, permissions } }`
- **`permissions`** = permissions résolues du rôle via `OrganizationService.resolveRolePermissions` :
  - rôle système (`owner` / `coach` / `athlete`) → `ORG_ROLES` (config statique)
  - rôle custom → table `organizationRole` (même sanitisation que `listRoles`)

## AC
- [x] **401** si non connecté (`AuthGuard` sans session)
- [x] **404** si pas membre — aucune org active *ou* aucun membership dans l'org active
- [x] `permissions` cohérent avec la config rôles

## Vérifié manuellement (base seedée)
| Scénario | Résultat |
|---|---|
| Sans cookie | `401` |
| Connecté, pas d'org active | `404 "Aucune organisation active"` |
| Coach, org active | `{ role: "coach", permissions: { member: ["read"] } }` |
| Owner, org active | `{ role: "owner", permissions: { organization: [...], member: [...], invitation: [...], role: [...] } }` |

Contrepartie front : ZaYtI/tri_manager_app#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)